### PR TITLE
Fix for medium.com urls with @ in the path

### DIFF
--- a/domainutil/util.go
+++ b/domainutil/util.go
@@ -115,17 +115,17 @@ func stripURLParts(url string) string {
 		url = url[index+3:]
 	}
 
-	// Now, if the url looks like this: username:password@www.example.com/path?query=?
-	// we remove the content before the '@' symbol
-	if index := strings.Index(url, "@"); index > -1 {
-		url = url[index+1:]
-	}
-
 	// Strip path (and query with it)
 	if index := strings.Index(url, "/"); index > -1 {
 		url = url[:index]
 	} else if index := strings.Index(url, "?"); index > -1 { // Strip query if path is not found
 		url = url[:index]
+	}
+
+	// Now, if the url looks like this: username:password@www.example.com/path?query=?
+	// we remove the content before the '@' symbol
+	if index := strings.Index(url, "@"); index > -1 {
+		url = url[index+1:]
 	}
 
 	// Convert domain to unicode

--- a/domainutil/util_test.go
+++ b/domainutil/util_test.go
@@ -21,7 +21,7 @@ func TestSplitDomain(t *testing.T) {
 		"wikipedia.org":                                    {"wikipedia", "org"},
 		".org":                                             {"org"},
 		"org":                                              nil,
-		"a.b.c.d.wikipedia.org": {"a", "b", "c", "d", "wikipedia", "org"},
+		"a.b.c.d.wikipedia.org":                            {"a", "b", "c", "d", "wikipedia", "org"},
 	}
 
 	for url, array := range cases {
@@ -83,7 +83,7 @@ func TestSubdomain(t *testing.T) {
 		"gama.google.com":             "gama",
 		"gama.google.co.uk":           "gama",
 		"beta.gama.google.co.uk":      "beta.gama",
-		"": "",
+		"":                            "",
 	}
 
 	//Test each domain, some should fail (expected)
@@ -217,22 +217,23 @@ func BenchmarkDomain(b *testing.B) {
 func TestStripURLParts(t *testing.T) {
 	//Test cases
 	cases := map[string]string{
-		"http://google.com":                                    "google.com",
-		"http://google.com/ding?true":                          "google.com",
-		"google.com/?ding=false":                               "google.com",
-		"google.com?ding=false":                                "google.com",
-		"nonexist.***":                                         "nonexist.***",
-		"google.com":                                           "google.com",
-		"google.co.uk":                                         "google.co.uk",
-		"gama.google.com":                                      "gama.google.com",
-		"gama.google.co.uk":                                    "gama.google.co.uk",
-		"beta.gama.google.co.uk":                               "beta.gama.google.co.uk",
-		"https://beta.gama.google.co.uk":                       "beta.gama.google.co.uk",
-		"xn--n3h.example":                                      "☃.example",
-		"xn--äää":                                              "",
-		"http://admin:adminpw@google.com":                      "google.com",
-		"admin:adminpw@gama.google.com":                        "gama.google.com",
+		"http://google.com":               "google.com",
+		"http://google.com/ding?true":     "google.com",
+		"google.com/?ding=false":          "google.com",
+		"google.com?ding=false":           "google.com",
+		"nonexist.***":                    "nonexist.***",
+		"google.com":                      "google.com",
+		"google.co.uk":                    "google.co.uk",
+		"gama.google.com":                 "gama.google.com",
+		"gama.google.co.uk":               "gama.google.co.uk",
+		"beta.gama.google.co.uk":          "beta.gama.google.co.uk",
+		"https://beta.gama.google.co.uk":  "beta.gama.google.co.uk",
+		"xn--n3h.example":                 "☃.example",
+		"xn--äää":                         "",
+		"http://admin:adminpw@google.com": "google.com",
+		"admin:adminpw@gama.google.com":   "gama.google.com",
 		"https://admin:adminpw@gama.google.com/path?key=value": "gama.google.com",
+		"http://medium.com/@example/example":                   "medium.com",
 	}
 
 	//Test each domain, some should fail (expected)


### PR DESCRIPTION
Thanks for the awesome utility :clap:!

Currently the site medium uses urls like `medium.com/@user/article` [example](https://medium.com/@Policy4.0/why-indias-supreme-court-ruling-won-t-change-the-fate-of-cryptocurrencies-decisively-24549674b13b).  Currently an empty string is returned by `Domain()` for all of them.

I just swapped the order of the removing the path portion with the removing the piece before the `@`.  This way handles both the weird medium urls with an `@` in the path and the `user:pass@...` urls.

My change messed up the nice alignment in `util_test.go` on one of the test data sections.  On go version `go1.13.4` running `gofmt domainutil/util_test.go` doesn't align the `TestStripURLParts` map. If this is an issue I can try to manually align it!