### PR TITLE
Fix #25: In `Domain`, strip trailing dot from domain name if present

### DIFF
--- a/domainutil/util.go
+++ b/domainutil/util.go
@@ -10,7 +10,7 @@ import (
 // If quantity matches the number of subdomains in domain, this function returns true.
 func HasSubdomainQuantity(domain string, quantity int) bool {
 	domainSplit := SplitDomain(domain)
-	if len(domainSplit) - 2 == quantity {
+	if len(domainSplit)-2 == quantity {
 		return true
 	}
 	return false
@@ -82,6 +82,11 @@ func Domain(url string) string {
 	parts := strings.Split(domain, ".")
 	currentTld := *tlds
 	foundTld := false
+
+	// Trailing periods are permitted
+	if parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
 
 	// Cycle trough parts in reverse
 	if len(parts) > 1 {

--- a/domainutil/util_test.go
+++ b/domainutil/util_test.go
@@ -206,6 +206,25 @@ func TestDomain(t *testing.T) {
 	}
 }
 
+// TestDomainrailingDot tests that Domain() accepts trailing dots in host names
+func TestDomainTrailingDot(t *testing.T) {
+	//Test cases
+	cases := map[string]string{
+		"http://google.com":       "google.com",
+		"http://google.com.":      "google.com",
+		"http://google.com./":     "google.com",
+		"http://google.com./page": "google.com",
+	}
+
+	//Test each domain, some should fail (expected)
+	for url, expected := range cases {
+		domain := Domain(url)
+		if domain != expected {
+			t.Errorf("Url (%q) returned (%s) as domain, but expected (%s)", url, domain, expected)
+		}
+	}
+}
+
 // BenchmarkDomain benchmarks Domain() function
 func BenchmarkDomain(b *testing.B) {
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
See issue #25 for context.

This PR fixes an issue in the `Domain` function whereby domains with trailing dots aren't parsed properly despite being valid.